### PR TITLE
Updated client to use Docker host IP address

### DIFF
--- a/client/cldcmds/deployment.py
+++ b/client/cldcmds/deployment.py
@@ -8,13 +8,20 @@ import requests
 
 import common
 
+
 class Deployment(object):
+
+    DOCKER_HOST='localhost'
 
     log = logging.getLogger(__name__)
     log.setLevel(logging.INFO)
 
     def __init__(self):
-        pass
+        if os.path.exists("../docker_host.txt"):
+            fp = open("../docker_host.txt", "r")
+            line = fp.readline()
+            parts = line.split("=")
+            Deployment.DOCKER_HOST=parts[1].strip()
 
     def _make_tarfile(self, output_filename, source_dir):
         with tarfile.open(output_filename, "w:gz") as tar:
@@ -56,7 +63,8 @@ class Deployment(object):
 
     def create_service_instance(self, service_info, cloud_info):
         #service_list = self._parse_service_info(service_info)
-        req = urllib2.Request("http://localhost:5002/deployments")
+        req_url = ("http://{host}:5002/deployments").format(host=Deployment.DOCKER_HOST)
+        req = urllib2.Request(req_url)
         #req = urllib2.Request("http://127.0.0.1:5000/deployments")
         #req = urllib2.Request("http://192.168.33.10:5000/deployments")
         req.add_header('Content-Type', 'application/octet-stream')
@@ -93,7 +101,8 @@ class Deployment(object):
 
         data = {'app': app_info, 'service': service_info, 'cloud': cloud_info}
 
-        req = urllib2.Request("http://localhost:5002/deployments")
+        req_url=("http://{host}:5002/deployments").format(host=Deployment.DOCKER_HOST)
+        req = urllib2.Request(req_url)
         #req = urllib2.Request("http://127.0.0.1:5000/deployments")
         #req = urllib2.Request("http://192.168.33.10:5000/deployments")
         req.add_header('Content-Type', 'application/octet-stream')
@@ -111,7 +120,8 @@ class Deployment(object):
         return track_url
 
     def service_delete(self, dep_id):
-        app_url = "http://localhost:5002/servicesdep/" + dep_id
+        app_url = ("http://{host}:5002/servicesdep/").format(host=Deployment.DOCKER_HOST)
+        app_url = app_url + dep_id
         response = requests.delete(app_url)
         if response.status_code == 404:
             print("Service with deploy-id %s not found." % dep_id)
@@ -120,7 +130,8 @@ class Deployment(object):
         return response
 
     def service_secure(self, dep_id):
-        app_url = "http://localhost:5002/servicesdep/" + dep_id
+        app_url = ("http://{host}:5002/servicesdep/").format(host=Deployment.DOCKER_HOST)
+        app_url = app_url + dep_id
         response = requests.put(app_url)
         if response.status_code == 404:
             print("Service with deploy-id %s not found." % dep_id)
@@ -132,7 +143,8 @@ class Deployment(object):
 
 
     def delete(self, dep_id):
-        app_url = "http://localhost:5002/deployments/" + dep_id
+        app_url = ("http://{host}:5002/deployments/").format(host=Deployment.DOCKER_HOST)
+        app_url = app_url + dep_id
         response = requests.delete(app_url)
         if response.status_code == 404:
             print("Application with deploy-id %s not found." % dep_id)
@@ -141,7 +153,8 @@ class Deployment(object):
         return response
 
     def logs(self, dep_id):
-        app_url = "http://localhost:5002/logs/" + dep_id
+        app_url = ("http://{host}:5002/logs/").format(host=Deployment.DOCKER_HOST)
+        app_url = app_url + dep_id
         req = urllib2.Request(app_url)
         app_data = ''
         try:
@@ -154,7 +167,8 @@ class Deployment(object):
         return app_data
 
     def get(self, dep_id):
-        app_url = "http://localhost:5002/deployments/" + dep_id
+        app_url = ("http://{host}:5002/deployments/").format(host=Deployment.DOCKER_HOST)
+        app_url = app_url + dep_id
         req = urllib2.Request(app_url)
         app_data = ''
         try:
@@ -167,7 +181,7 @@ class Deployment(object):
         return app_data
 
     def get_all_apps(self):
-        app_url = "http://localhost:5002/apps"
+        app_url = ("http://{host}:5002/apps").format(host=Deployment.DOCKER_HOST)
         req = urllib2.Request(app_url)
         response = urllib2.urlopen(req)
         app_data = response.fp.read()
@@ -175,7 +189,8 @@ class Deployment(object):
         return app_data
 
     def get_app_info(self, appname):
-        app_url = "http://localhost:5002/apps/" + appname
+        app_url = ("http://{host}:5002/apps/").format(host=Deployment.DOCKER_HOST)
+        app_url = app_url + appname
         req = urllib2.Request(app_url)
         app_data = ''
         try:
@@ -188,7 +203,7 @@ class Deployment(object):
         return app_data
 
     def get_all_services(self):
-        app_url = "http://localhost:5002/services"
+        app_url = ("http://{host}:5002/services").format(host=Deployment.DOCKER_HOST)
         req = urllib2.Request(app_url)
         response = urllib2.urlopen(req)
         service_data = response.fp.read()
@@ -196,7 +211,8 @@ class Deployment(object):
         return service_data
 
     def get_service_info(self, service_name):
-        service_url = "http://localhost:5002/services/" + service_name
+        service_url = ("http://{host}:5002/services/").format(host=Deployment.DOCKER_HOST)
+        service_url = service_url + service_name
         req = urllib2.Request(service_url)
         response = urllib2.urlopen(req)
         service_data = response.fp.read()
@@ -204,7 +220,8 @@ class Deployment(object):
         return service_data
 
     def get_service_info_from_id(self, deploy_id):
-        service_url = "http://localhost:5002/servicesdep/" + deploy_id
+        service_url = ("http://{host}:5002/servicesdep/").format(host=Deployment.DOCKER_HOST)
+        service_url = service_url + deploy_id
         req = urllib2.Request(service_url)
         response = urllib2.urlopen(req)
         service_data = response.fp.read()
@@ -215,7 +232,8 @@ class Deployment(object):
         improper_input = common.verify_cloud(cloud)
         if improper_input:
             exit()
-        app_url = "http://localhost:5002/clouds/" + cloud
+        app_url = ("http://{host}:5002/clouds/").format(host=Deployment.DOCKER_HOST)
+        app_url = app_url + cloud
         req = urllib2.Request(app_url)
         response = urllib2.urlopen(req)
         app_data = response.fp.read()

--- a/lib/install-mac.sh
+++ b/lib/install-mac.sh
@@ -22,6 +22,15 @@ touch install.log
 install_log="install.log"
 echo "Installing FirstMile. Installation logs stored in $install_log"
 
+# Determine Docker HOST IP
+DOCKER_MACHINE_ENV=`docker-machine env default` || { echo "docker-machine env default failed" ; exit 1; }
+cat > docker_machine_env <<EOF
+  echo $DOCKER_MACHINE_ENV
+EOF
+DOCKER_HOST=`grep DOCKER_HOST docker_machine_env | sed 's/\// /'g | sed 's/:/ /'g | awk '{print $3}'`
+echo "DOCKER_HOST=$DOCKER_HOST"
+echo "DOCKER_HOST=$DOCKER_HOST" > ./client/docker_host.txt
+
 # Install FirstMile client
 echo "Installing FirstMile client"
 pip install virtualenv >> $install_log
@@ -69,6 +78,7 @@ echo "CMD [\"python\", \"/src/cld.py\"]" >> Dockerfile
 # Start the firstmile server container
 #set -x
 echo "Starting FirstMile"
+eval "$(docker-machine env default)"
 docker build -t firstmile-img . >> $install_log
 docker run -u ubuntu -p 5002:5002 -v /var/run/docker.sock:/var/run/docker.sock -v $HOME:/home/ubuntu -d firstmile-img >> $install_log
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ docker-py
 testtools
 requests
 gevent
+cliff


### PR DESCRIPTION
- Default value of Docker host is 'localhost'.
  For Docker for Mac this does not work.
  Instead we need to use the IP address of the
  Docker for Mac.

- Updated lib/install-mac.sh to parse VM IP address
- Updated client side code to construct URLs with
  the value of the Docker host. Default is 'localhost'
  For Mac, it is the value that will be parsed by
  install script