### PR TITLE
Commented out docker-cleanup calls from run-tests.sh

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,24 +1,24 @@
 #!/bin/bash
 
 echo "Running functional tests for local-docker"
-cd tools
-./docker-cleanup.sh
-cd ..
+#cd tools
+#./docker-cleanup.sh
+#cd ..
 python -m testtools.run functionaltests.local.test_local.TestLocal.test_app_deploy_no_service
 python -m testtools.run functionaltests.local.test_local.TestLocal.test_app_deploy_with_mysql_service
 python -m testtools.run functionaltests.local.test_local.TestLocal.test_mysql_instance_provision
 
 echo "Running functional tests for google"
-cd tools
-./docker-cleanup.sh
-cd ..
+#cd tools
+#./docker-cleanup.sh
+#cd ..
 python -m testtools.run functionaltests.google.test_google.TestGoogle.test_app_deploy_no_service
 python -m testtools.run functionaltests.google.test_google.TestGoogle.test_app_deploy_with_mysql_service
 python -m testtools.run functionaltests.google.test_google.TestGoogle.test_mysql_instance_provision
 
 echo "Running functional tests for aws"
-cd tools
-./docker-cleanup.sh
-cd ..
+#cd tools
+#./docker-cleanup.sh
+#cd ..
 python -m testtools.run functionaltests.aws.test_aws.TestAWS.test_app_deploy_no_service
 


### PR DESCRIPTION
Brute forced docker cleanup deletes all the local containers.
This is not correct -- we should only delete containers
that are created/managed by FirstMile.

For now, commenting out calls to docker-cleanup.sh